### PR TITLE
Fix Typo in SpotifyPlayerTrack Type Definition

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,7 @@ export type SpotifyPlayerError = 'initialization_error' | 'authentication_error'
 export type SpotifyPlayerTrack = {
   uri: string, // Spotify URI
   id?: string, // Spotify ID from URI (can be null)
-  type: 'track' | 'episode' | 'add', // Content type: can be "track", "episode" or "ad"
+  type: 'track' | 'episode' | 'ad', // Content type: can be "track", "episode" or "ad"
   media_type: 'audio' | 'video', // Type of file: can be "audio" or "video"
   name: string, // Name of content
   is_playable: boolean, // Flag indicating whether it can be played


### PR DESCRIPTION
## Overview
This pull request corrects a typo in the type definition of the `SpotifyPlayerTrack`. Specifically, it changes the incorrect 'add' to the correct 'ad' in the type options. Additionally, I have verified that other properties and event names in our type definitions are consistent with the official Spotify Web Playback SDK documentation.

## Changes
- In the `SpotifyPlayerTrack` type definition, corrected the typo in the `type` field from 'add' to 'ad'. The corrected line now accurately reflects the intended content types: 'track', 'episode', and 'ad'.
- Reviewed and confirmed that other type definitions align with the Spotify Web Playback SDK documentation.

## Documentation Reference
The changes are made in accordance with the Spotify Web Playback SDK documentation, as found here: [Spotify Web Playback SDK Reference](https://developer.spotify.com/documentation/web-playback-sdk/reference#webplaybackplayer-object:~:text=//%20Content%20type%3A%20can%20be%20%22track%22%2C%20%22episode%22%20or%20%22ad%22)

Thank you for considering this update to the type definition.
